### PR TITLE
Exception message should contain the string representation of token

### DIFF
--- a/Ripple.Core/Types/Amount.cs
+++ b/Ripple.Core/Types/Amount.cs
@@ -96,7 +96,7 @@ namespace Ripple.Core.Types
 
                     return new Amount((string)valueToken, (string)currencyToken, (string)issuerToken);
                 default:
-                    throw new InvalidJsonException("Can not create Amount from `{token}`");
+                    throw new InvalidJsonException($"Can not create Amount from `{token}`");
             }
         }
 


### PR DESCRIPTION
At the moment, when serialization of the Amount type fails, the message is simply 'Can not create Amount from `{token}`' which isn't particularly helpful. Seems like string interpolation was intended in the first place.